### PR TITLE
Flag for vervosing or error message for tasks that do not exist

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -47,7 +47,10 @@ func NewApp() *cli.App {
 			return
 		}
 
-		if len(c.Args()) == 0 {
+		args := c.Args()
+		if len(args) > 0 {
+			cli.ShowCommandHelp(c, args[0])
+		} else {
 			cli.ShowAppHelp(c)
 		}
 	}


### PR DESCRIPTION
It would be very useful if were added flag "-v", for that works just like in "go test -v".

Now, if you write a task that does not exist, then you don't know if it was run correctly or is that such task does not exist

```
gotask not-exist
```
