### PR TITLE
Function Fatal

### DIFF
--- a/tasking/t.go
+++ b/tasking/t.go
@@ -60,6 +60,18 @@ func (t *T) Failed() bool {
 	return t.failed
 }
 
+// Fatal is equivalent to Error followed by a call to os.Exit(1).
+func (t *T) Fatal(args ...interface{}) {
+	t.Error(args)
+	os.Exit(1)
+}
+
+// Fatalf is equivalent to Errorf followed by a call to os.Exit(1).
+func (t *T) Fatalf(format string, args ...interface{}) {
+	t.Errorf(format, args)
+	os.Exit(1)
+}
+
 // Log formats its arguments using default formatting, analogous to Println.
 func (t *T) Log(args ...interface{}) {
 	fmt.Println(args...)


### PR DESCRIPTION
It would be useful to add functions:

```
func (c *T) Fatal(args ...interface{})
func (c *T) Fatalf(format string, args ...interface{})
```

like in package testing (http://golang.org/pkg/testing/#T)

I know that function "(*T).FailNow()" makes not sense in gotask so those funtcions would be the same than Error and Errorf.

So, you can build scripts just like if you were using package testing.
