### PR TITLE
Import cycle not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ func TaskXxx(t *tasking.T) {
 ```
 
 where `Xxx` can be any alphanumeric string (but the first letter must not be in [a-z]) and serves to identify the task name.
+The task must be defined inside a [GOPATH](http://golang.org/doc/code.html#GOPATH) so that `gotask` can find and compile it.
 
 ### Task Name
 


### PR DESCRIPTION
If I invoke a task in a folder outside GOPATH the following error is raised:

<pre>
$ gotask hello
can't load package: : import cycle not allowed
package .
    imports .
: import cycle not allowed
package .
    imports .
2014/01/11 16:51:07 exit status 1
</pre>
